### PR TITLE
Enforcing utf-8 encoding in Closing Behaviour report

### DIFF
--- a/autobahntestsuite/autobahntestsuite/fuzzing.py
+++ b/autobahntestsuite/autobahntestsuite/fuzzing.py
@@ -881,7 +881,7 @@ class FuzzingFactory:
       f.write('      <table>\n')
       f.write('         <tr class="stats_header"><td>Key</td><td class="left">Value</td><td class="left">Description</td></tr>\n')
       for c in cbv:
-         f.write('         <tr class="stats_row"><td>%s</td><td class="left">%s</td><td class="left">%s</td></tr>\n' % (c[0], case[c[0]], c[1]))
+         f.write(('         <tr class="stats_row"><td>%s</td><td class="left">%s</td><td class="left">%s</td></tr>\n' % (c[0], case[c[0]], c[1])).encode("utf-8"))
       f.write('      </table>')
       f.write("      <br/><hr/>\n")
 


### PR DESCRIPTION
It can happen that the value contains non ascii character, which causes creating report to fail [1]. Enforcing utf-8 during creation of the report prevents this failure [1]


```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/autobahntestsuite/wstest.py", line 272, in start
    reactor.run()
  File "/usr/lib64/python2.7/site-packages/twisted/internet/base.py", line 1192, in run
    self.mainLoop()
  File "/usr/lib64/python2.7/site-packages/twisted/internet/base.py", line 1204, in mainLoop
    self.doIteration(t)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/epollreactor.py", line 396, in doPoll
    log.callWithLogger(selectable, _drdw, selectable, fd, event)
--- <exception caught here> ---
  File "/usr/lib64/python2.7/site-packages/twisted/python/log.py", line 88, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File "/usr/lib64/python2.7/site-packages/twisted/python/log.py", line 73, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "/usr/lib64/python2.7/site-packages/twisted/python/context.py", line 118, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/usr/lib64/python2.7/site-packages/twisted/python/context.py", line 81, in callWithContext
    return func(*args,**kw)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/posixbase.py", line 627, in _doReadOrWrite
    self._disconnectSelectable(selectable, why, inRead)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/posixbase.py", line 257, in _disconnectSelectable
    selectable.readConnectionLost(f)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/tcp.py", line 278, in readConnectionLost
    self.connectionLost(reason)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/tcp.py", line 485, in connectionLost
    self.connector.connectionLost(reason)
  File "/usr/lib64/python2.7/site-packages/twisted/internet/base.py", line 1085, in connectionLost
    self.factory.clientConnectionLost(self, reason)
  File "/usr/lib/python2.7/site-packages/autobahntestsuite/fuzzing.py", line 1259, in clientConnectionLost
    self.createReports()
  File "/usr/lib/python2.7/site-packages/autobahntestsuite/fuzzing.py", line 467, in createReports
    self.createAgentCaseReportHTML(agentId, caseId, self.outdir)
  File "/usr/lib/python2.7/site-packages/autobahntestsuite/fuzzing.py", line 884, in createAgentCaseReportHTML
    f.write('         <tr class="stats_row"><td>%s</td><td class="left">%s</td><td class="left">%s</td></tr>\n' % (c[0], case[c[0]], c[1]))
exceptions.UnicodeEncodeError: 'ascii' codec can't encode character u'\u2026' in position 194: ordinal not in range(128)
```
